### PR TITLE
tinkerbell: defer client creation to first resource operation

### DIFF
--- a/tinkerbell/resource_hardware.go
+++ b/tinkerbell/resource_hardware.go
@@ -80,7 +80,12 @@ func validateHardwareData(m interface{}, p cty.Path) diag.Diagnostics {
 }
 
 func resourceHardwareCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).HardwareClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.hardwareClient
 
 	hw := pkg.HardwareWrapper{}
 
@@ -106,7 +111,12 @@ func resourceHardwareCreate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceHardwareUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).HardwareClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.hardwareClient
 
 	hw := pkg.HardwareWrapper{}
 
@@ -125,6 +135,8 @@ func resourceHardwareUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	if _, err := c.Push(ctx, &hardware.PushRequest{Data: hw.Hardware}); err != nil {
 		return diagsFromErr(fmt.Errorf("pushing hardware data: %w", err))
 	}
+
+	d.SetId(hw.Hardware.Id)
 
 	return nil
 }
@@ -158,7 +170,12 @@ func getHardware(ctx context.Context, c hardware.HardwareServiceClient, uuid str
 }
 
 func resourceHardwareRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).HardwareClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.hardwareClient
 
 	h, err := getHardware(ctx, c, d.Id())
 	if err != nil {
@@ -184,7 +201,12 @@ func resourceHardwareRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceHardwareDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).HardwareClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.hardwareClient
 
 	req := hardware.DeleteRequest{
 		Id: d.Id(),

--- a/tinkerbell/resource_template.go
+++ b/tinkerbell/resource_template.go
@@ -88,7 +88,12 @@ func getTemplate(ctx context.Context, c template.TemplateClient, id string) (*te
 }
 
 func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).TemplateClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.templateClient
 
 	req := template.WorkflowTemplate{
 		Name: d.Get("name").(string),
@@ -106,7 +111,12 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).TemplateClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.templateClient
 
 	t, err := getTemplate(ctx, c, d.Id())
 	if err != nil {
@@ -136,7 +146,12 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).TemplateClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.templateClient
 
 	t, err := getTemplate(ctx, c, d.Id())
 	if err != nil {
@@ -161,7 +176,12 @@ func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).TemplateClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.templateClient
 
 	t, err := getTemplate(ctx, c, d.Id())
 	if err != nil {

--- a/tinkerbell/resource_workflow.go
+++ b/tinkerbell/resource_workflow.go
@@ -36,7 +36,12 @@ func resourceWorkflow() *schema.Resource {
 }
 
 func resourceWorkflowCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).WorkflowClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.workflowClient
 
 	req := workflow.CreateRequest{
 		Template: d.Get("template").(string),
@@ -82,7 +87,12 @@ func getWorkflow(ctx context.Context, c workflow.WorkflowSvcClient, uuid string)
 }
 
 func resourceWorkflowRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).WorkflowClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.workflowClient
 
 	wf, err := getWorkflow(ctx, c, d.Id())
 	if err != nil {
@@ -99,7 +109,12 @@ func resourceWorkflowRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceWorkflowDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*tinkClient).WorkflowClient
+	tc, err := m.(*tinkClientConfig).New()
+	if err != nil {
+		return diagsFromErr(fmt.Errorf("creating Tink client: %w", err))
+	}
+
+	c := tc.workflowClient
 
 	wf, err := getWorkflow(ctx, c, d.Id())
 	if err != nil {


### PR DESCRIPTION
As Terraform was not originally designed to Terraform code feed and
configure another provider, if one uses interpolation in provider
configuration, which is a legitimate use (e.g. when you create server
and deploy Tinkerbell using the same Terraform stack which later on adds
hardware entries), client creation will fail, as it is not guaranteed
that the fields will be populated on time.

This commit defers Tinkerbell client creation to the point where first
resource is actually created, which can be ensured with Terraform
depends_on option on the resources level.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>