### PR TITLE
Add explicit dependency between workflow and hardware

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,10 @@ resource "tinkerbell_workflow" "foo" {
   hardwares = <<EOF
 {"device_1":"ff:ff:ff:ff:ff:ff"}
 EOF
+
+  depends_on = [
+    tinkerbell_hardware.foo,
+  ]
 }
 ```
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -83,6 +83,10 @@ resource "tinkerbell_workflow" "foo" {
   hardwares = <<EOF
 {"device_1":"ff:ff:ff:ff:ff:ff"}
 EOF
+
+  depends_on = [
+    tinkerbell_hardware.foo,
+  ]
 }
 ```
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -90,4 +90,8 @@ resource "tinkerbell_workflow" "foo" {
   hardwares = <<EOF
 {"device_1":"ff:ff:ff:ff:ff:ff"}
 EOF
+
+  depends_on = [
+    tinkerbell_hardware.foo,
+  ]
 }

--- a/tinkerbell/resource_workflow_test.go
+++ b/tinkerbell/resource_workflow_test.go
@@ -21,6 +21,10 @@ resource "tinkerbell_workflow" "foo" {
 	hardwares = <<EOF
 {"device_1":"%s"}
 EOF
+
+	depends_on = [
+		tinkerbell_hardware.foo,
+	]
 }
 `,
 		testAccHardware(testAccHardwareConfig(name, rMAC)),


### PR DESCRIPTION
Until #5 is resolved, this is needed to ensure that hardware entry is
created before workflow.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>